### PR TITLE
feat: file args & alternate app icon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,5 @@
 # Go workspace file
 go.work
 
-# Patcher files
-Unbound.ipa
-Unbound
+# macOS
+*.DS_Store

--- a/archive.go
+++ b/archive.go
@@ -40,7 +40,7 @@ func extract() {
 }
 
 func archive() {
-	logger.Debugf("Preparing to create IPA at \"%s\"", output)
+	logger.Debugf("Preparing to create ipa at \"%s\"", output)
 
 	format := archiver.Zip{CompressionLevel: flate.BestCompression}
 	zip := directory + ".zip"

--- a/archive.go
+++ b/archive.go
@@ -40,7 +40,7 @@ func extract() {
 }
 
 func archive() {
-	logger.Debugf("Attempting to archive \"%s\"", directory)
+	logger.Debugf("Preparing to create IPA at \"%s\"", output)
 
 	format := archiver.Zip{CompressionLevel: flate.BestCompression}
 	zip := directory + ".zip"
@@ -57,30 +57,38 @@ func archive() {
 		logger.Info("Previous archive cleaned up.")
 	}
 
-	logger.Infof("Archiving \"%s\" to \"%s\"", directory, zip)
+	logger.Debugf("Creating temporary archive from \"%s\"", directory)
 	err := format.Archive([]string{filepath.Join(directory, "Payload")}, zip)
 	if err != nil {
-		logger.Errorf("Failed to archive \"%s\": %v", zip, err)
+		logger.Errorf("Failed to create archive: %v", err)
 		exit()
 	}
 
-	if _, err := os.Stat("Unbound.ipa"); err == nil {
-		logger.Debug("Detected previous Unbound ipa, cleaning it up...")
+	// Check if output file already exists and remove it if necessary
+	if _, err := os.Stat(output); err == nil {
+		logger.Debugf("Detected existing file at output path, cleaning it up...")
 
-		err := os.Remove("Unbound.ipa")
+		err := os.Remove(output)
 		if err != nil {
-			logger.Errorf("Failed to clean up previous Unbound ipa: %s", err)
+			logger.Errorf("Failed to clean up existing output file: %s", err)
 			exit()
 		}
 
-		logger.Info("Previous Unbound ipa cleaned up.")
+		logger.Info("Existing output file cleaned up.")
 	}
 
-	err = os.Rename(zip, "Unbound.ipa")
-	if err != nil {
-		logger.Errorf("Failed to rename \"%s\": %v", zip, err)
+	// Create output directory if it doesn't exist
+	outputDir := filepath.Dir(output)
+	if err := os.MkdirAll(outputDir, 0755); err != nil {
+		logger.Errorf("Failed to create output directory: %v", err)
 		exit()
 	}
 
-	logger.Infof("Successfully archived \"%s\" to \"Unbound.ipa\"", zip)
+	err = os.Rename(zip, output)
+	if err != nil {
+		logger.Errorf("Failed to create output file \"%s\": %v", output, err)
+		exit()
+	}
+
+	logger.Infof("Successfully created \"%s\"", output)
 }

--- a/archive.go
+++ b/archive.go
@@ -65,15 +65,15 @@ func archive() {
 	}
 
 	if _, err := os.Stat("Unbound.ipa"); err == nil {
-		logger.Debug("Detected previous Unbound IPA, cleaning it up...")
+		logger.Debug("Detected previous Unbound ipa, cleaning it up...")
 
 		err := os.Remove("Unbound.ipa")
 		if err != nil {
-			logger.Errorf("Failed to clean up previous Unbound IPA: %s", err)
+			logger.Errorf("Failed to clean up previous Unbound ipa: %s", err)
 			exit()
 		}
 
-		logger.Info("Previous Unbound IPA cleaned up.")
+		logger.Info("Previous Unbound ipa cleaned up.")
 	}
 
 	err = os.Rename(zip, "Unbound.ipa")

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ var logger = log.NewWithOptions(os.Stderr, log.Options{
 })
 
 var (
-	info      map[string]interface{}
+	info      map[string]any
 	directory string
 	assets    string
 	ipa       string
@@ -26,24 +26,21 @@ var (
 func main() {
 	app := &cli.App{
 		Name:  "patcher-ios",
-		Usage: "Patches the Discord IPA with icons, utilities and features to ease usability.",
+		Usage: "Patches the Discord ipa with icons, utilities and features to ease usability.",
 		Action: func(context *cli.Context) error {
 			ipa = context.Args().Get(0)
 
 			if ipa == "" {
-				logger.Error("Please provide a path to the IPA.")
+				logger.Error("Please provide a path to the ipa.")
 				os.Exit(1)
 			}
 
-			logger.Infof("Requested IPA patch for \"%s\"", ipa)
+			logger.Infof("Requested ipa patch for \"%s\"", ipa)
 
 			extract()
 			loadInfo()
 
 			setReactNavigationName()
-			setSupportedDevices()
-			setFileAccess()
-			setAppName()
 			setIcons()
 
 			saveInfo()

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/charmbracelet/log"
@@ -21,21 +22,53 @@ var (
 	directory string
 	assets    string
 	ipa       string
+	output    string
 )
 
 func main() {
 	app := &cli.App{
 		Name:  "patcher-ios",
 		Usage: "Patches the Discord ipa with icons, utilities and features to ease usability.",
+		Flags: []cli.Flag{
+			&cli.StringFlag{
+				Name:     "input",
+				Aliases:  []string{"i"},
+				Usage:    "Input path for the Discord ipa file to patch",
+				Required: true,
+			},
+			&cli.StringFlag{
+				Name:     "output",
+				Aliases:  []string{"o"},
+				Usage:    "Output path for the patched ipa file",
+				Required: true,
+			},
+		},
 		Action: func(context *cli.Context) error {
-			ipa = context.Args().Get(0)
+			ipa = context.String("input")
+			output = context.String("output")
 
 			if ipa == "" {
-				logger.Error("Please provide a path to the ipa.")
+				logger.Error("Please provide a path to the input ipa using --input or -i flag.")
 				os.Exit(1)
 			}
 
+			// Convert relative paths to absolute to ensure consistency
+			if !filepath.IsAbs(ipa) {
+				absPath, err := filepath.Abs(ipa)
+				if err == nil {
+					ipa = absPath
+				}
+			}
+
+			if !filepath.IsAbs(output) {
+				absPath, err := filepath.Abs(output)
+				if err == nil {
+					output = absPath
+				}
+			}
+
 			logger.Infof("Requested ipa patch for \"%s\"", ipa)
+			logger.Infof("Output will be saved to \"%s\"", output)
 
 			extract()
 			loadInfo()

--- a/patcher.go
+++ b/patcher.go
@@ -19,32 +19,6 @@ type Manifest struct {
 	Hashes map[string]string `json:"hashes"`
 }
 
-func setSupportedDevices() {
-	logger.Debug("Setting supported devices...")
-
-	delete(info, "UISupportedDevices")
-
-	logger.Info("Supported devices set.")
-}
-
-func setAppName() {
-	logger.Debug("Setting app name...")
-
-	info["CFBundleName"] = "Unbound"
-	info["CFBundleDisplayName"] = "Unbound"
-
-	logger.Info("App name set.")
-}
-
-func setFileAccess() {
-	logger.Debug("Setting file access...")
-
-	info["UISupportsDocumentBrowser"] = true
-	info["UIFileSharingEnabled"] = true
-
-	logger.Info("File access enabled.")
-}
-
 func setIcons() {
 	logger.Debug("Downloading app icons...")
 
@@ -90,7 +64,7 @@ func setReactNavigationName() {
 	content, err := os.ReadFile(manifestPath)
 
 	if err != nil {
-		logger.Errorf("Couldn't find manifest.json inside the IPA payload. %v", err)
+		logger.Errorf("Couldn't find manifest.json inside the ipa payload. %v", err)
 		exit()
 	}
 

--- a/patcher.go
+++ b/patcher.go
@@ -27,20 +27,35 @@ func setIcons() {
 
 	logger.Info("Downloaded app icons.")
 
-	logger.Debug("Applying app icons...")
+	logger.Debug("Adding Unbound as alternate icon...")
 
-	info["CFBundleIcons"].(map[string]interface{})["CFBundlePrimaryIcon"].(map[string]interface{})["CFBundleIconName"] = "UnboundIcon"
-	info["CFBundleIcons"].(map[string]interface{})["CFBundlePrimaryIcon"].(map[string]interface{})["CFBundleIconFiles"] = []string{"UnboundIcon60x60"}
-	info["CFBundleIcons~ipad"].(map[string]interface{})["CFBundlePrimaryIcon"].(map[string]interface{})["CFBundleIconName"] = "UnboundIcon"
-	info["CFBundleIcons~ipad"].(map[string]interface{})["CFBundlePrimaryIcon"].(map[string]interface{})["CFBundleIconFiles"] = []string{"UnboundIcon60x60", "UnboundIcon76x76"}
+	// Add UnboundIcon to iPhone alternate icons
+	iPhoneIcons := info["CFBundleIcons"].(map[string]interface{})
+	if iPhoneIcons["CFBundleAlternateIcons"] == nil {
+		iPhoneIcons["CFBundleAlternateIcons"] = make(map[string]interface{})
+	}
+	alternateIcons := iPhoneIcons["CFBundleAlternateIcons"].(map[string]interface{})
+	alternateIcons["UnboundIcon"] = map[string]interface{}{
+		"CFBundleIconFiles": []string{"UnboundIcon60x60"},
+	}
+
+	// Add UnboundIcon to iPad alternate icons
+	iPadIcons := info["CFBundleIcons~ipad"].(map[string]interface{})
+	if iPadIcons["CFBundleAlternateIcons"] == nil {
+		iPadIcons["CFBundleAlternateIcons"] = make(map[string]interface{})
+	}
+	alternateIconsIpad := iPadIcons["CFBundleAlternateIcons"].(map[string]interface{})
+	alternateIconsIpad["UnboundIcon"] = map[string]interface{}{
+		"CFBundleIconFiles": []string{"UnboundIcon60x60", "UnboundIcon76x76"},
+	}
 
 	zip := archiver.Zip{OverwriteExisting: true}
 	discord := filepath.Join(directory, "Payload", "Discord.app")
 
 	if err := zip.Unarchive(icons, discord); err == nil {
-		logger.Info("Applied app icons.")
+		logger.Info("Added Unbound as alternate app icon.")
 	} else {
-		logger.Errorf("Failed to apply app icons: %v", err)
+		logger.Errorf("Failed to add Unbound app icon: %v", err)
 		exit()
 	}
 }

--- a/util.go
+++ b/util.go
@@ -68,13 +68,13 @@ func loadInfo() {
 	file, err := os.Open(path)
 
 	if err != nil {
-		logger.Error("Couldn't find Info.plist. Is the provided zip an IPA file?")
+		logger.Error("Couldn't find Info.plist. Is the provided zip an ipa file?")
 		exit()
 	}
 
 	decoder := plist.NewDecoder(file)
 	if err := decoder.Decode(&info); err != nil {
-		logger.Error("Couldn't find Info.plist. Is the provided zip an IPA file?")
+		logger.Error("Couldn't find Info.plist. Is the provided zip an ipa file?")
 		exit()
 	}
 }


### PR DESCRIPTION
this pr adresses a few things:

- input and output files are now supplied as dedicated args
- redundant steps that are automatically performed by cyan during the injection step have been removed
- rather than outright replacing the default app icon we now add an alternate app icon set